### PR TITLE
Options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Use the following code in your product template to make use of this new controll
 	    <input type="hidden" name="items[{{ loop.index }}][purchasableId]" value="{{ product.defaultVariant.id }}">
         <input type="hidden" name="items[{{ loop.index }}][qty]" value="1">
         <input type="text" name="items[{{ loop.index }}][note]">
+        <select name="items[{{ loop.index }}][options[color]]">
+            <option value="blue">Blue</option>
+            <option value="white">White</option>
+            <option value="red">Red</option>
+        </select>
     {% endfor %}
 </form>
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use the following code in your product template to make use of this new controll
 	    <input type="hidden" name="items[{{ loop.index }}][purchasableId]" value="{{ product.defaultVariant.id }}">
         <input type="hidden" name="items[{{ loop.index }}][qty]" value="1">
         <input type="text" name="items[{{ loop.index }}][note]">
-        <select name="items[{{ loop.index }}][options[color]]">
+        <select name="items[{{ loop.index }}][options][color]">
             <option value="blue">Blue</option>
             <option value="white">White</option>
             <option value="red">Red</option>

--- a/multiadd/MultiAddPlugin.php
+++ b/multiadd/MultiAddPlugin.php
@@ -22,7 +22,7 @@ class MultiAddPlugin extends BasePlugin
 
     public function getVersion()
     {
-        return '0.0.4';
+        return '0.0.5';
     }
 
     public function getDeveloper()

--- a/multiadd/controllers/MultiAddController.php
+++ b/multiadd/controllers/MultiAddController.php
@@ -54,16 +54,8 @@ class MultiAddController extends Commerce_BaseFrontEndController
                     $qty              = isset($item['qty']) ? (int)$item['qty'] : 0; 
                     $note             = isset($item['note']) ? $item['note'] : ""; 
                     $error            = "";
-                    $options          = [];
-
-                    //we can have an arbitrary number of options[whatever] = value in the POST
-                    foreach ($item as $innerKey => $innerItem){
-                        if (strpos($innerKey, "options") === 0 ){
-                            $keyName = substr($innerKey,8);
-                            $keyName = rtrim($keyName,"]");
-                            $options[$keyName] = $innerItem;
-                        }
-                    }                 
+                    //the following line means you can pass abritrary options like this: items[0][options][note]
+                    $options          = isset($item['options']) ? $item['options'] : [];         
 
                     $cart->setContentFromPost('fields');
 

--- a/multiadd/controllers/MultiAddController.php
+++ b/multiadd/controllers/MultiAddController.php
@@ -9,7 +9,8 @@ class MultiAddController extends Commerce_BaseFrontEndController
     private function logError($error){
         MultiAddPlugin::log($error, LogLevel::Error);
     }
-   
+
+  
     public function actionMultiAdd()
     {
 
@@ -52,6 +53,17 @@ class MultiAddController extends Commerce_BaseFrontEndController
                     $purchasableId    = $item['purchasableId'];
                     $qty              = isset($item['qty']) ? (int)$item['qty'] : 0; 
                     $note             = isset($item['note']) ? $item['note'] : ""; 
+                    $error            = "";
+                    $options          = [];
+
+                    //we can have an arbitrary number of options[whatever] = value in the POST
+                    foreach ($item as $innerKey => $innerItem){
+                        if (strpos($innerKey, "options") === 0 ){
+                            $keyName = substr($innerKey,8);
+                            $keyName = rtrim($keyName,"]");
+                            $options[$keyName] = $innerItem;
+                        }
+                    }                 
 
                     $cart->setContentFromPost('fields');
 
@@ -61,8 +73,7 @@ class MultiAddController extends Commerce_BaseFrontEndController
                             print_r($item);
                             echo '</pre>';
                         }
-                        // @TODO add note here...
-                        if (!craft()->commerce_cart->addToCart($cart, $purchasableId, $qty, $note, $error)) {
+                        if (!craft()->commerce_cart->addToCart($cart, $purchasableId, $qty, $note, $options, $error)) {
                             $errors[] = $error;
                             $needsRollback = true;                            
                             break;


### PR DESCRIPTION
Ok here it is.  Pretty simple in the end, and it keeps the syntax consistent with regular addToCart and the MultiAdd approach.

Added to the docs too (code pinched from the Commerce examples).

I will not lie, testing has been....light.  _It works for me_ (tm).  But I am using only one option, haven't got anything that uses multiples.  I am sure if someone does and it breaks, they'll let us know ;)
