### PR TITLE
If an order fails to save, return an error.

### DIFF
--- a/multiadd/services/MultiAdd_CartService.php
+++ b/multiadd/services/MultiAdd_CartService.php
@@ -169,9 +169,11 @@ class MultiAdd_CartService extends BaseApplicationComponent
                 CommerceDbHelper::commitStackedTransaction();
             }
             else{
+                $errors = $order->getErrors();
+                $error = array_pop($errors);
                 MultiAddPlugin::logError('Error when saving order');
                 CommerceDbHelper::rollbackStackedTransaction();
-                throw new Exception(Craft::t('Error saving order in multiadd'));                
+                return false;
             }
 
             //raising event


### PR DESCRIPTION
If an order fails to save, instead of just throwing an exception, return the first error from the order.
